### PR TITLE
Reader: dotted pairs, quasiquote, characters, and positions

### DIFF
--- a/apps/aimax_scheme/lib/aimax/scheme/builtins.ex
+++ b/apps/aimax_scheme/lib/aimax/scheme/builtins.ex
@@ -37,12 +37,20 @@ defmodule Aimax.Scheme.Builtins do
         end
       end,
       "sort" => fn [l] -> Enum.sort(l) end,
-      "cons" => fn [h, t] when is_list(t) -> [h | t] end,
+      # any tail, not only a list: the reader reads (a . b), so cons must
+      # build it too. list? tells a proper list from a dotted pair.
+      "cons" => fn [h, t] -> [h | t] end,
       "car" => fn [[h | _]] -> h end,
       "cdr" => fn [[_ | t]] -> t end,
       "list" => fn args -> args end,
       "null?" => fn [x] -> x == [] end,
       "pair?" => fn [x] -> is_list(x) and x != [] end,
+      "list?" => fn [x] -> proper_list?(x) end,
+      "char?" => fn [x] -> match?({:char, _}, x) end,
+      "char->integer" => fn [{:char, cp}] -> cp end,
+      "integer->char" => fn [i] when is_integer(i) -> {:char, i} end,
+      "string->char" => fn [<<cp::utf8, _::binary>>] -> {:char, cp} end,
+      "char->string" => fn [{:char, cp}] -> <<cp::utf8>> end,
       "length" => fn [l] -> length(l) end,
       "append" => fn lists -> Enum.concat(lists) end,
       "reverse" => fn [l] -> Enum.reverse(l) end,
@@ -245,7 +253,13 @@ defmodule Aimax.Scheme.Builtins do
       "abs" => "(abs N) — return the absolute value of N.",
       "member" => "(member X LST) — return the tail of LST from the first X, or false.",
       "sort" => "(sort LST) — return LST sorted in ascending term order.",
-      "cons" => "(cons H T) — prepend H to the list T; T must be a list.",
+      "cons" => "(cons H T) — prepend H to T. A non-list T makes a dotted pair.",
+      "list?" => "(list? X) — return true if X is a proper list.",
+      "char?" => "(char? X) — return true if X is a character.",
+      "char->integer" => "(char->integer C) — return the codepoint of C.",
+      "integer->char" => "(integer->char N) — return the character for codepoint N.",
+      "string->char" => "(string->char S) — return the first character of S.",
+      "char->string" => "(char->string C) — return C as a one-character string.",
       "car" => "(car LST) — return the first element of LST.",
       "cdr" => "(cdr LST) — return LST without its first element.",
       "list" => "(list X ...) — return a list of the arguments.",
@@ -341,4 +355,8 @@ defmodule Aimax.Scheme.Builtins do
     end
   end
 
+
+  defp proper_list?([]), do: true
+  defp proper_list?([_ | t]), do: proper_list?(t)
+  defp proper_list?(_), do: false
 end

--- a/apps/aimax_scheme/lib/aimax/scheme/eval.ex
+++ b/apps/aimax_scheme/lib/aimax/scheme/eval.ex
@@ -25,7 +25,12 @@ defmodule Aimax.Scheme.Eval do
       when is_number(expr) or is_binary(expr) or is_boolean(expr),
       do: {expr, store}
 
+  def eval({:char, _} = ch, _env, store), do: {ch, store}
+
   def eval([{:sym, "quote"}, form], _env, store), do: {form, store}
+
+  # `(a ,b ,@c) — the template is data, and unquote evaluates one hole in it
+  def eval([{:sym, "quasiquote"}, template], env, store), do: quasi(template, 1, env, store)
 
   def eval([{:sym, "if"}, c, t], env, store), do: eval([{:sym, "if"}, c, t, :void], env, store)
 
@@ -111,10 +116,15 @@ defmodule Aimax.Scheme.Eval do
   end
 
   # application
-  def eval([op | arg_forms], env, store) do
+  def eval([op | arg_forms], env, store) when is_list(arg_forms) do
     {f, store} = eval_arg(op, env, store)
     {args, store} = eval_args(arg_forms, env, store, [])
     apply_fn(f, args, store)
+  end
+
+  # (f . x) — a dotted pair is data, and nothing applies it
+  def eval([_ | _] = improper, _env, _store) do
+    raise Error, message: "cannot call a dotted pair: #{Aimax.Scheme.Printer.print(improper)}"
   end
 
   def eval(other, _env, _store) do
@@ -150,7 +160,14 @@ defmodule Aimax.Scheme.Eval do
     e in Error ->
       reraise e, __STACKTRACE__
 
-    e in [ArgumentError, FunctionClauseError, MatchError, CaseClauseError, ArithmeticError, KeyError] ->
+    e in [
+      ArgumentError,
+      FunctionClauseError,
+      MatchError,
+      CaseClauseError,
+      ArithmeticError,
+      KeyError
+    ] ->
       reraise Error,
               [message: "#{name}: #{Exception.message(e)}"],
               __STACKTRACE__
@@ -158,6 +175,60 @@ defmodule Aimax.Scheme.Eval do
 
   def apply_fn(other, _args, _store) do
     raise Error, message: "not a function: #{inspect(other)}"
+  end
+
+  # --- quasiquote ------------------------------------------------------------
+  #
+  # DEPTH counts the nesting: a nested quasiquote raises it, an unquote lowers
+  # it, and only an unquote at depth 1 evaluates. Anything else rebuilds as
+  # data, so `(a `(b ,(c))) keeps its inner template intact.
+
+  defp quasi([{:sym, "unquote"}, form], 1, env, store), do: eval_arg(form, env, store)
+
+  defp quasi([{:sym, "unquote"}, form], depth, env, store) do
+    {inner, store} = quasi(form, depth - 1, env, store)
+    {[{:sym, "unquote"}, inner], store}
+  end
+
+  defp quasi([{:sym, "quasiquote"}, form], depth, env, store) do
+    {inner, store} = quasi(form, depth + 1, env, store)
+    {[{:sym, "quasiquote"}, inner], store}
+  end
+
+  defp quasi(list, depth, env, store) when is_list(list),
+    do: quasi_list(list, depth, env, store, [])
+
+  defp quasi(other, _depth, _env, store), do: {other, store}
+
+  defp quasi_list([], _depth, _env, store, acc), do: {Enum.reverse(acc), store}
+
+  # `(1 . ,x) reads as (1 unquote x): an unquote in the tail is the dotted tail
+  defp quasi_list([{:sym, "unquote"}, form], 1, env, store, acc) do
+    {tail, store} = eval_arg(form, env, store)
+    {List.foldl(acc, tail, fn x, t -> [x | t] end), store}
+  end
+
+  defp quasi_list([[{:sym, "unquote-splicing"}, form] | rest], 1, env, store, acc) do
+    {spliced, store} = eval_arg(form, env, store)
+
+    unless is_list(spliced) do
+      raise Error,
+        message: "unquote-splicing needs a list, got: #{Aimax.Scheme.Printer.print(spliced)}"
+    end
+
+    quasi_list(rest, 1, env, store, Enum.reverse(spliced, acc))
+  end
+
+  # (a . ,b) — the dotted tail is one more template
+  defp quasi_list([head | tail], depth, env, store, acc) when not is_list(tail) do
+    {head, store} = quasi(head, depth, env, store)
+    {tail, store} = quasi(tail, depth, env, store)
+    {List.foldl([head | acc], tail, fn x, t -> [x | t] end), store}
+  end
+
+  defp quasi_list([head | rest], depth, env, store, acc) do
+    {head, store} = quasi(head, depth, env, store)
+    quasi_list(rest, depth, env, store, [head | acc])
   end
 
   # --- helpers ---------------------------------------------------------------
@@ -243,7 +314,9 @@ defmodule Aimax.Scheme.Eval do
   defp parse_optionals!([name | more], opt), do: parse_optionals!(more, [name | opt])
 
   defp rest_name!([name]) when name not in ["&optional", "&rest"], do: name
-  defp rest_name!(other), do: raise(Error, message: "&rest takes exactly one name, got: #{inspect(other)}")
+
+  defp rest_name!(other),
+    do: raise(Error, message: "&rest takes exactly one name, got: #{inspect(other)}")
 
   defp bind_params!(req, opt, rest, args) do
     nreq = length(req)

--- a/apps/aimax_scheme/lib/aimax/scheme/printer.ex
+++ b/apps/aimax_scheme/lib/aimax/scheme/printer.ex
@@ -1,25 +1,49 @@
 defmodule Aimax.Scheme.Printer do
   @moduledoc "Scheme value -> string. `print` is `write`-style, `display` is human-style."
 
+  @char_names %{
+    0 => "nul",
+    7 => "alarm",
+    8 => "backspace",
+    ?\t => "tab",
+    ?\n => "newline",
+    ?\r => "return",
+    27 => "escape",
+    ?\s => "space",
+    127 => "delete"
+  }
+
   def print(true), do: "#t"
   def print(false), do: "#f"
   def print(:void), do: ""
   def print({:sym, s}), do: s
+  def print({:char, cp}), do: "#\\" <> char_name(cp)
   # printable_limit: inspect truncates strings past 4096 bytes by default —
   # print is the RPC wire format ("eval is the API"), so it must be faithful
   def print(s) when is_binary(s), do: inspect(s, printable_limit: :infinity)
   def print(i) when is_integer(i), do: Integer.to_string(i)
   def print(f) when is_float(f), do: Float.to_string(f)
-  def print(l) when is_list(l), do: "(" <> Enum.map_join(l, " ", &print/1) <> ")"
+  def print(l) when is_list(l), do: "(" <> items(l, &print/1) <> ")"
+
   def print({:closure, {req, opt, rest}, _, _}) do
     opt = if opt == [], do: [], else: ["&optional" | opt]
     rest = if rest, do: ["&rest", rest], else: []
     "#<procedure (#{Enum.join(req ++ opt ++ rest, " ")})>"
   end
+
   def print({:builtin, name, _}), do: "#<builtin #{name}>"
   def print(other), do: inspect(other)
 
+  def display({:char, cp}), do: <<cp::utf8>>
   def display(s) when is_binary(s), do: s
-  def display(l) when is_list(l), do: "(" <> Enum.map_join(l, " ", &display/1) <> ")"
+  def display(l) when is_list(l), do: "(" <> items(l, &display/1) <> ")"
   def display(other), do: print(other)
+
+  defp char_name(cp), do: Map.get(@char_names, cp, <<cp::utf8>>)
+
+  # an improper list prints its tail after a dot: (1 . 2), (1 2 . 3)
+  defp items([], _f), do: ""
+  defp items([x], f), do: f.(x)
+  defp items([x | rest], f) when is_list(rest), do: f.(x) <> " " <> items(rest, f)
+  defp items([x | tail], f), do: f.(x) <> " . " <> f.(tail)
 end

--- a/apps/aimax_scheme/lib/aimax/scheme/reader.ex
+++ b/apps/aimax_scheme/lib/aimax/scheme/reader.ex
@@ -6,24 +6,65 @@ defmodule Aimax.Scheme.Reader do
     * symbols  -> `{:sym, "name"}`   (never atoms — user code must not grow the atom table)
     * numbers  -> integer | float
     * strings  -> binary
+    * chars    -> `{:char, codepoint}`
     * booleans -> `true` | `false`  (#t / #f)
-    * lists    -> Elixir lists
+    * lists    -> Elixir lists; `(a . b)` reads as the improper list `[a | b]`
+
+  Syntax the reader accepts:
+
+      'x  `x  ,x  ,@x       quote, quasiquote, unquote, unquote-splicing
+      (a . b)               dotted pair
+      #\\a #\\space #\\x41    characters
+      #t #f #true #false    booleans
+      #x1f #o17 #b1010 #d9  radix prefixes
+      |a symbol|            symbol with any characters in the name
+      ; line                line comment
+      #| nested |#          block comment, nests
+      #;datum               datum comment: the reader drops the next form
+
+  Every error names a line and a column.
   """
 
   defmodule Error do
-    defexception [:message]
+    @moduledoc """
+    A syntax error, with the line and the column of the offending text.
+    `incomplete: true` means the text stops inside a form. More text can
+    still make it valid, so a REPL asks for the next line instead of
+    reporting the error.
+    """
+    defexception [:message, :line, :column, incomplete: false]
   end
 
   @doc "Read all top-level forms from a string."
   def read_all(src) do
-    tokens = tokenize(src)
-    read_forms(tokens, [])
+    src |> tokenize() |> read_forms([])
   end
 
-  @doc "Read a single form; returns {form, remaining_tokens}."
+  @doc """
+  Read one form. Returns `{:ok, form, rest_of_source}`, `{:incomplete, reason}`
+  when the text stops inside a list or a string, or `{:error, exception}`.
+
+  The REPL and the RPC reader use this: `:incomplete` means "ask for more
+  text", an error means "report it now".
+  """
   def read_one(src) do
-    src |> tokenize() |> read_expr()
+    case tokenize(src) do
+      [] ->
+        {:incomplete, "empty input"}
+
+      tokens ->
+        {form, rest} = read_expr(tokens)
+        {:ok, form, rest_source(rest, src)}
+    end
+  rescue
+    e in Error -> if e.incomplete, do: {:incomplete, e.message}, else: {:error, e}
   end
+
+  # the tokens carry offsets, so the unread tail is a slice of the source
+  defp rest_source([], _src), do: ""
+
+  defp rest_source([{_tag, _val, _line, _col, offset} | _], src),
+    do: binary_part(src, offset, byte_size(src) - offset)
 
   defp read_forms([], acc), do: Enum.reverse(acc)
 
@@ -32,72 +73,264 @@ defmodule Aimax.Scheme.Reader do
     read_forms(rest, [form | acc])
   end
 
+  defp fail(msg, line, col, incomplete \\ false) do
+    raise Error,
+      message: "line #{line}, column #{col}: #{msg}",
+      line: line,
+      column: col,
+      incomplete: incomplete
+  end
+
   # --- tokenizer -------------------------------------------------------------
+  #
+  # A token is {tag, value, line, column, byte_offset}. The position rides on
+  # every token so the parser can name a line and a column for any error.
 
-  defp tokenize(src), do: tok(src, [])
+  @delims ~c[ \t\r\n()";'`,|]
 
-  defp tok(<<>>, acc), do: Enum.reverse(acc)
-  defp tok(<<c, rest::binary>>, acc) when c in ~c[ \t\r\n], do: tok(rest, acc)
-  defp tok(<<";", rest::binary>>, acc), do: tok(skip_line(rest), acc)
-  defp tok(<<"(", rest::binary>>, acc), do: tok(rest, [:lparen | acc])
-  defp tok(<<")", rest::binary>>, acc), do: tok(rest, [:rparen | acc])
-  defp tok(<<"'", rest::binary>>, acc), do: tok(rest, [:quote | acc])
+  defp tokenize(src), do: tok(src, 1, 1, byte_size(src), [])
 
-  defp tok(<<"\"", rest::binary>>, acc) do
-    {str, rest} = tok_string(rest, [])
-    tok(rest, [{:str, str} | acc])
+  defp tok(<<>>, _l, _c, _n, acc), do: Enum.reverse(acc)
+
+  defp tok(<<"\n", rest::binary>>, l, _c, n, acc), do: tok(rest, l + 1, 1, n, acc)
+
+  defp tok(<<ch, rest::binary>>, l, c, n, acc) when ch in ~c[ \t\r],
+    do: tok(rest, l, c + 1, n, acc)
+
+  defp tok(<<";", rest::binary>>, l, c, n, acc) do
+    {rest, l, c} = skip_line(rest, l, c + 1)
+    tok(rest, l, c, n, acc)
   end
 
-  defp tok(bin, acc) do
-    {atom, rest} = tok_atom(bin, [])
-    tok(rest, [{:atom, atom} | acc])
+  defp tok(<<"#|", rest::binary>>, l, c, n, acc) do
+    {rest, l, c} = skip_block(rest, l, c + 2, 1)
+    tok(rest, l, c, n, acc)
   end
 
-  defp skip_line(<<>>), do: <<>>
-  defp skip_line(<<"\n", rest::binary>>), do: rest
-  defp skip_line(<<_, rest::binary>>), do: skip_line(rest)
+  defp tok(<<"#;", rest::binary>> = bin, l, c, n, acc),
+    do: tok(rest, l, c + 2, n, [{:datum_comment, nil, l, c, off(n, bin)} | acc])
 
-  defp tok_string(<<>>, _), do: raise(Error, message: "unterminated string")
-  defp tok_string(<<"\"", rest::binary>>, acc), do: {acc |> Enum.reverse() |> IO.iodata_to_binary(), rest}
-  defp tok_string(<<"\\\"", rest::binary>>, acc), do: tok_string(rest, ["\"" | acc])
-  defp tok_string(<<"\\\\", rest::binary>>, acc), do: tok_string(rest, ["\\" | acc])
-  defp tok_string(<<"\\n", rest::binary>>, acc), do: tok_string(rest, ["\n" | acc])
-  defp tok_string(<<"\\t", rest::binary>>, acc), do: tok_string(rest, ["\t" | acc])
-  defp tok_string(<<c::utf8, rest::binary>>, acc), do: tok_string(rest, [<<c::utf8>> | acc])
-
-  defp tok_atom(<<c, _::binary>> = bin, acc) when c in ~c[ \t\r\n()";'] or bin == <<>> do
-    {acc |> Enum.reverse() |> IO.iodata_to_binary(), bin}
+  defp tok(<<"#\\", rest::binary>> = bin, l, c, n, acc) do
+    {cp, rest, width} = tok_char(rest, l, c)
+    tok(rest, l, c + 2 + width, n, [{:char, cp, l, c, off(n, bin)} | acc])
   end
 
-  defp tok_atom(<<c::utf8, rest::binary>>, acc), do: tok_atom(rest, [<<c::utf8>> | acc])
-  defp tok_atom(<<>>, acc), do: {acc |> Enum.reverse() |> IO.iodata_to_binary(), <<>>}
+  defp tok(<<"(", rest::binary>> = bin, l, c, n, acc),
+    do: tok(rest, l, c + 1, n, [{:lparen, nil, l, c, off(n, bin)} | acc])
 
-  # --- parser ----------------------------------------------------------------
+  defp tok(<<")", rest::binary>> = bin, l, c, n, acc),
+    do: tok(rest, l, c + 1, n, [{:rparen, nil, l, c, off(n, bin)} | acc])
 
-  defp read_expr([]), do: raise(Error, message: "unexpected end of input")
-  defp read_expr([:lparen | rest]), do: read_list(rest, [])
-  defp read_expr([:rparen | _]), do: raise(Error, message: "unexpected )")
+  defp tok(<<"'", rest::binary>> = bin, l, c, n, acc),
+    do: tok(rest, l, c + 1, n, [{:quote, nil, l, c, off(n, bin)} | acc])
 
-  defp read_expr([:quote | rest]) do
-    {form, rest} = read_expr(rest)
-    {[{:sym, "quote"}, form], rest}
+  defp tok(<<"`", rest::binary>> = bin, l, c, n, acc),
+    do: tok(rest, l, c + 1, n, [{:quasiquote, nil, l, c, off(n, bin)} | acc])
+
+  defp tok(<<",@", rest::binary>> = bin, l, c, n, acc),
+    do: tok(rest, l, c + 2, n, [{:unquote_splicing, nil, l, c, off(n, bin)} | acc])
+
+  defp tok(<<",", rest::binary>> = bin, l, c, n, acc),
+    do: tok(rest, l, c + 1, n, [{:unquote, nil, l, c, off(n, bin)} | acc])
+
+  defp tok(<<"\"", rest::binary>> = bin, l, c, n, acc) do
+    {str, rest, l2, c2} = tok_string(rest, l, c + 1, [], {l, c})
+    tok(rest, l2, c2, n, [{:str, str, l, c, off(n, bin)} | acc])
   end
 
-  defp read_expr([{:str, s} | rest]), do: {s, rest}
-  defp read_expr([{:atom, a} | rest]), do: {parse_atom(a), rest}
-
-  defp read_list([:rparen | rest], acc), do: {Enum.reverse(acc), rest}
-  defp read_list([], _), do: raise(Error, message: "unterminated list")
-
-  defp read_list(tokens, acc) do
-    {form, rest} = read_expr(tokens)
-    read_list(rest, [form | acc])
+  # |a symbol with spaces|
+  defp tok(<<"|", rest::binary>> = bin, l, c, n, acc) do
+    {name, rest, l2, c2} = tok_bar(rest, l, c + 1, [])
+    tok(rest, l2, c2, n, [{:atom, {:sym, name}, l, c, off(n, bin)} | acc])
   end
 
-  defp parse_atom("#t"), do: true
-  defp parse_atom("#f"), do: false
+  defp tok(bin, l, c, n, acc) do
+    {text, rest, width} = tok_atom(bin, [], 0)
 
-  defp parse_atom(a) do
+    token =
+      if text == ".",
+        do: {:dot, nil, l, c, off(n, bin)},
+        else: {:atom, parse_atom(text, l, c), l, c, off(n, bin)}
+
+    tok(rest, l, c + width, n, [token | acc])
+  end
+
+  # the byte offset where a token starts: the whole source minus what was
+  # still unread when the tokenizer reached it
+  defp off(n, bin), do: n - byte_size(bin)
+
+  defp skip_line(<<>>, l, c), do: {<<>>, l, c}
+  defp skip_line(<<"\n", rest::binary>>, l, _c), do: {rest, l + 1, 1}
+  defp skip_line(<<_, rest::binary>>, l, c), do: skip_line(rest, l, c + 1)
+
+  defp skip_block(<<>>, l, c, _depth), do: fail("unterminated block comment", l, c, true)
+  defp skip_block(<<"|#", rest::binary>>, l, c, 1), do: {rest, l, c + 2}
+  defp skip_block(<<"|#", rest::binary>>, l, c, d), do: skip_block(rest, l, c + 2, d - 1)
+  defp skip_block(<<"#|", rest::binary>>, l, c, d), do: skip_block(rest, l, c + 2, d + 1)
+  defp skip_block(<<"\n", rest::binary>>, l, _c, d), do: skip_block(rest, l + 1, 1, d)
+  defp skip_block(<<_::utf8, rest::binary>>, l, c, d), do: skip_block(rest, l, c + 1, d)
+
+  # --- strings ---------------------------------------------------------------
+
+  # the error points at the opening quote, not at the end of the file
+  defp tok_string(<<>>, _l, _c, _acc, {sl, sc}), do: fail("unterminated string", sl, sc, true)
+
+  defp tok_string(<<"\"", rest::binary>>, l, c, acc, _start),
+    do: {acc |> Enum.reverse() |> IO.iodata_to_binary(), rest, l, c + 1}
+
+  # \x41; is a hex codepoint. Anything else after \x is not an escape at all,
+  # so the reader keeps both characters: regex strings hold "\\x" sequences.
+  defp tok_string(<<"\\x", rest::binary>>, l, c, acc, start) do
+    case scan_hex(rest, []) do
+      {cp, rest, width} -> tok_string(rest, l, c + 2 + width, [<<cp::utf8>> | acc], start)
+      nil -> tok_string(rest, l, c + 2, ["\\x" | acc], start)
+    end
+  end
+
+  # \<newline> with intraline space around it folds away: a long string can
+  # wrap in the source and stay one line of text
+  defp tok_string(<<"\\", rest::binary>>, l, c, acc, start) do
+    case skip_intraline(rest) do
+      <<"\n", rest2::binary>> ->
+        tok_string(skip_intraline(rest2), l + 1, 1, acc, start)
+
+      <<>> ->
+        {sl, sc} = start
+        fail("unterminated string", sl, sc, true)
+
+      _ ->
+        <<esc, rest2::binary>> = rest
+        tok_string(rest2, l, c + 2, [string_escape(esc) | acc], start)
+    end
+  end
+
+  defp tok_string(<<"\n", rest::binary>>, l, _c, acc, start),
+    do: tok_string(rest, l + 1, 1, ["\n" | acc], start)
+
+  defp tok_string(<<ch::utf8, rest::binary>>, l, c, acc, start),
+    do: tok_string(rest, l, c + 1, [<<ch::utf8>> | acc], start)
+
+  defp skip_intraline(<<ch, rest::binary>>) when ch in ~c[ \t], do: skip_intraline(rest)
+  defp skip_intraline(bin), do: bin
+
+  defp string_escape(?n), do: "\n"
+  defp string_escape(?t), do: "\t"
+  defp string_escape(?r), do: "\r"
+  defp string_escape(?a), do: <<7>>
+  defp string_escape(?b), do: <<8>>
+  defp string_escape(?0), do: <<0>>
+  defp string_escape(?\\), do: "\\"
+  defp string_escape(?"), do: "\""
+  # not an escape: keep the backslash and the character, so a string can hold
+  # a regex ("^\\*+ ") without doubling every backslash
+  defp string_escape(ch), do: <<?\\, ch>>
+
+  # hex digits then a semicolon, or nil
+  defp scan_hex(<<";", _::binary>>, []), do: nil
+  defp scan_hex(<<";", rest::binary>>, acc), do: {digits_to_int(acc, 16), rest, length(acc) + 1}
+
+  defp scan_hex(<<ch, rest::binary>>, acc) when ch in ~c[0123456789abcdefABCDEF],
+    do: scan_hex(rest, [ch | acc])
+
+  defp scan_hex(_bin, _acc), do: nil
+
+  defp digits_to_int(rev_digits, base),
+    do: rev_digits |> Enum.reverse() |> IO.iodata_to_binary() |> String.to_integer(base)
+
+  # --- bar symbols -----------------------------------------------------------
+
+  defp tok_bar(<<>>, l, c, _acc), do: fail("unterminated |symbol|", l, c, true)
+
+  defp tok_bar(<<"|", rest::binary>>, l, c, acc),
+    do: {acc |> Enum.reverse() |> IO.iodata_to_binary(), rest, l, c + 1}
+
+  defp tok_bar(<<"\\|", rest::binary>>, l, c, acc), do: tok_bar(rest, l, c + 2, ["|" | acc])
+  defp tok_bar(<<"\\\\", rest::binary>>, l, c, acc), do: tok_bar(rest, l, c + 2, ["\\" | acc])
+  defp tok_bar(<<"\n", rest::binary>>, l, _c, acc), do: tok_bar(rest, l + 1, 1, ["\n" | acc])
+
+  defp tok_bar(<<ch::utf8, rest::binary>>, l, c, acc),
+    do: tok_bar(rest, l, c + 1, [<<ch::utf8>> | acc])
+
+  # --- characters ------------------------------------------------------------
+
+  @char_names %{
+    "space" => ?\s,
+    "newline" => ?\n,
+    "linefeed" => ?\n,
+    "tab" => ?\t,
+    "return" => ?\r,
+    "nul" => 0,
+    "null" => 0,
+    "alarm" => 7,
+    "backspace" => 8,
+    "escape" => 27,
+    "esc" => 27,
+    "delete" => 127,
+    "rubout" => 127
+  }
+
+  defp tok_char(<<>>, l, c), do: fail("unterminated character literal", l, c, true)
+
+  defp tok_char(bin, l, c) do
+    {name, rest, width} = tok_atom(bin, [], 0)
+
+    case name do
+      # an empty name means tok_atom stopped at once, on a delimiter. A
+      # delimiter is a character too: #\( #\) #\" #\; and #\<space>.
+      "" ->
+        <<ch::utf8, rest2::binary>> = bin
+        {ch, rest2, 1}
+
+      <<ch::utf8>> ->
+        {ch, rest, width}
+
+      <<"x", hex::binary>> when byte_size(hex) > 0 ->
+        case Integer.parse(hex, 16) do
+          {cp, ""} -> {cp, rest, width}
+          _ -> named_char(name, rest, width, l, c)
+        end
+
+      _ ->
+        named_char(name, rest, width, l, c)
+    end
+  end
+
+  defp named_char(name, rest, width, l, c) do
+    case Map.fetch(@char_names, String.downcase(name)) do
+      {:ok, cp} -> {cp, rest, width}
+      :error -> fail("unknown character name #\\#{name}", l, c)
+    end
+  end
+
+  # --- atoms -----------------------------------------------------------------
+
+  defp tok_atom(<<>>, acc, width),
+    do: {acc |> Enum.reverse() |> IO.iodata_to_binary(), <<>>, width}
+
+  defp tok_atom(<<ch, _::binary>> = bin, acc, width) when ch in @delims,
+    do: {acc |> Enum.reverse() |> IO.iodata_to_binary(), bin, width}
+
+  defp tok_atom(<<ch::utf8, rest::binary>>, acc, width),
+    do: tok_atom(rest, [<<ch::utf8>> | acc], width + 1)
+
+  defp parse_atom("#t", _l, _c), do: true
+  defp parse_atom("#true", _l, _c), do: true
+  defp parse_atom("#f", _l, _c), do: false
+  defp parse_atom("#false", _l, _c), do: false
+
+  defp parse_atom(<<"#", prefix, digits::binary>>, l, c) when prefix in ~c[xXoObBdD] do
+    base = radix(prefix)
+    {sign, digits} = sign_of(digits)
+
+    case Integer.parse(digits, base) do
+      {i, ""} when digits != "" -> sign * i
+      _ -> fail("bad number #{<<?#, prefix>>}#{digits}", l, c)
+    end
+  end
+
+  defp parse_atom(<<"#", _::binary>> = a, l, c), do: fail("unknown # syntax #{a}", l, c)
+
+  defp parse_atom(a, _l, _c) do
     case Integer.parse(a) do
       {i, ""} ->
         i
@@ -109,4 +342,72 @@ defmodule Aimax.Scheme.Reader do
         end
     end
   end
+
+  defp radix(p) when p in ~c[xX], do: 16
+  defp radix(p) when p in ~c[oO], do: 8
+  defp radix(p) when p in ~c[bB], do: 2
+  defp radix(p) when p in ~c[dD], do: 10
+
+  defp sign_of(<<"-", rest::binary>>), do: {-1, rest}
+  defp sign_of(<<"+", rest::binary>>), do: {1, rest}
+  defp sign_of(digits), do: {1, digits}
+
+  # --- parser ----------------------------------------------------------------
+
+  defp read_expr([]),
+    do: raise(Error, message: "unexpected end of input", line: 0, column: 0, incomplete: true)
+
+  defp read_expr([{:lparen, _, l, c, _} | rest]), do: read_list(rest, [], l, c)
+  defp read_expr([{:rparen, _, l, c, _} | _]), do: fail("unexpected )", l, c)
+  defp read_expr([{:dot, _, l, c, _} | _]), do: fail("unexpected . outside a list", l, c)
+
+  defp read_expr([{:datum_comment, _, _l, _c, _} | rest]) do
+    {_dropped, rest} = read_expr(rest)
+    read_expr(rest)
+  end
+
+  defp read_expr([{prefix, _, _l, _c, _} | rest])
+       when prefix in [:quote, :quasiquote, :unquote, :unquote_splicing] do
+    {form, rest} = read_expr(rest)
+    {[{:sym, prefix_name(prefix)}, form], rest}
+  end
+
+  defp read_expr([{:str, s, _l, _c, _} | rest]), do: {s, rest}
+  defp read_expr([{:char, cp, _l, _c, _} | rest]), do: {{:char, cp}, rest}
+  defp read_expr([{:atom, a, _l, _c, _} | rest]), do: {a, rest}
+
+  defp prefix_name(:quote), do: "quote"
+  defp prefix_name(:quasiquote), do: "quasiquote"
+  defp prefix_name(:unquote), do: "unquote"
+  defp prefix_name(:unquote_splicing), do: "unquote-splicing"
+
+  defp read_list([{:rparen, _, _, _, _} | rest], acc, _l, _c), do: {Enum.reverse(acc), rest}
+  defp read_list([], _acc, l, c), do: fail("unterminated list", l, c, true)
+
+  # (a . b) — the tail after the dot becomes the improper tail of the list
+  defp read_list([{:dot, _, dl, dc, _} | rest], acc, l, c) do
+    if acc == [], do: fail("a dotted pair needs a value before the .", dl, dc)
+
+    {tail, rest} = read_expr(rest)
+
+    case rest do
+      [{:rparen, _, _, _, _} | rest] -> {improper(Enum.reverse(acc), tail), rest}
+      [] -> fail("unterminated list", l, c, true)
+      [{_, _, tl, tc, _} | _] -> fail("a dotted pair takes one value after the .", tl, tc)
+    end
+  end
+
+  defp read_list([{:datum_comment, _, _, _, _} | rest], acc, l, c) do
+    {_dropped, rest} = read_expr(rest)
+    read_list(rest, acc, l, c)
+  end
+
+  defp read_list(tokens, acc, l, c) do
+    {form, rest} = read_expr(tokens)
+    read_list(rest, [form | acc], l, c)
+  end
+
+  # (a . (b c)) is (a b c): a list tail flattens, anything else stays improper
+  defp improper(head, tail) when is_list(tail), do: head ++ tail
+  defp improper(head, tail), do: List.foldr(head, tail, fn x, t -> [x | t] end)
 end

--- a/apps/aimax_scheme/test/aimax/scheme_reader_test.exs
+++ b/apps/aimax_scheme/test/aimax/scheme_reader_test.exs
@@ -1,0 +1,444 @@
+defmodule Aimax.SchemeReaderTest do
+  use ExUnit.Case, async: true
+
+  alias Aimax.Scheme
+  alias Aimax.Scheme.{Printer, Reader}
+
+  defp read(src), do: Reader.read_all(src)
+  defp read1(src), do: src |> Reader.read_all() |> hd()
+  defp run(src), do: (fn {:ok, v, _} -> v end).(Scheme.eval_string(Scheme.new(), src))
+  defp show(src), do: Printer.print(run(src))
+  defp err(src), do: (fn {:error, m} -> m end).(Scheme.eval_string(Scheme.new(), src))
+
+  defp sym(s), do: {:sym, s}
+
+  describe "atoms" do
+    test "integers, floats, and signs" do
+      assert read("0 -5 +7 3.5 -2.25 1e3 1.5e-2") == [0, -5, 7, 3.5, -2.25, 1.0e3, 1.5e-2]
+    end
+
+    test "a token that is not a number is a symbol" do
+      for s <- ["-", "+", "...", "1+", "a1", "set!", "string->list", "<=?", "x.y", "1/2"] do
+        assert read(s) == [sym(s)], "expected #{s} to read as a symbol"
+      end
+    end
+
+    test "booleans, long and short" do
+      assert read("#t #f #true #false") == [true, false, true, false]
+    end
+
+    test "radix prefixes" do
+      assert read("#x1f #X1F #b1010 #o17 #d42") == [31, 31, 10, 15, 42]
+      assert read("#x-ff #b+11") == [-255, 3]
+    end
+
+    test "a bad radix body names its line and column" do
+      assert_raise Reader.Error, ~r/line 1, column 1: bad number #xZZ/, fn -> read("#xZZ") end
+      assert_raise Reader.Error, ~r/bad number #x/, fn -> read("#x") end
+    end
+
+    test "an unknown # syntax is an error, not a symbol" do
+      assert_raise Reader.Error, ~r/unknown # syntax #foo/, fn -> read("#foo") end
+    end
+
+    test "|bar symbols| take any characters in the name" do
+      assert read("|a b|") == [sym("a b")]
+      assert read(~S{|a\|b|}) == [sym("a|b")]
+      assert read(~S{|a\\b|}) == [sym("a\\b")]
+      assert read("|(1 2)|") == [sym("(1 2)")]
+      assert read("|a| |b|") == [sym("a"), sym("b")]
+    end
+
+    test "an unterminated |symbol| is an error" do
+      assert_raise Reader.Error, ~r/unterminated \|symbol\|/, fn -> read("|abc") end
+    end
+
+    test "unicode passes through" do
+      assert read("λ") == [sym("λ")]
+      assert read(~s{"héllo ✓"}) == ["héllo ✓"]
+    end
+  end
+
+  describe "strings" do
+    test "the classic escapes" do
+      assert read(~S{"a\"b\\c\nd\te\rf"}) == ["a\"b\\c\nd\te\rf"]
+      assert read(~S{"\a\b\0"}) == [<<7, 8, 0>>]
+    end
+
+    test "\\x41; is a hex codepoint" do
+      assert read(~S{"a\x41;b"}) == ["aAb"]
+      assert read(~S{"\x3bb;"}) == ["λ"]
+    end
+
+    # regexes live in strings, and doubling every backslash makes them unreadable
+    test "an unknown escape keeps the backslash and the character" do
+      assert read(~S{"^\*+ "}) == [~S{^\*+ }]
+      assert read(~S{"\d+\s"}) == [~S{\d+\s}]
+      assert read(~S{"\x"}) == [~S{\x}]
+      assert read(~S{"\xzz"}) == [~S{\xzz}]
+    end
+
+    test "a backslash before a newline folds the line break away" do
+      assert read("\"a\\\n     b\"") == ["ab"]
+    end
+
+    test "a literal newline stays in the string" do
+      assert read("\"a\nb\"") == ["a\nb"]
+    end
+
+    test "an unterminated string names its line and column" do
+      assert_raise Reader.Error, ~r/line 1, column 5: unterminated string/, fn ->
+        read(~S{abc "def})
+      end
+    end
+  end
+
+  describe "characters" do
+    test "one plain character" do
+      assert read("#\\a #\\Z #\\7 #\\λ") == [{:char, ?a}, {:char, ?Z}, {:char, ?7}, {:char, ?λ}]
+    end
+
+    test "named characters" do
+      assert read("#\\space #\\newline #\\tab #\\return") == [
+               {:char, ?\s},
+               {:char, ?\n},
+               {:char, ?\t},
+               {:char, ?\r}
+             ]
+
+      assert read("#\\nul #\\null #\\alarm #\\backspace #\\escape #\\delete #\\rubout") == [
+               {:char, 0},
+               {:char, 0},
+               {:char, 7},
+               {:char, 8},
+               {:char, 27},
+               {:char, 127},
+               {:char, 127}
+             ]
+    end
+
+    test "names are case insensitive" do
+      assert read("#\\Space #\\NEWLINE") == [{:char, ?\s}, {:char, ?\n}]
+    end
+
+    test "#\\xNN is a hex codepoint" do
+      assert read("#\\x41 #\\x3bb") == [{:char, ?A}, {:char, ?λ}]
+    end
+
+    test "a delimiter is itself a character" do
+      assert read("#\\( #\\) #\\; #\\' #\\\"") == [
+               {:char, ?(},
+               {:char, ?)},
+               {:char, ?;},
+               {:char, ?'},
+               {:char, ?"}
+             ]
+    end
+
+    test "a character stops at the next delimiter" do
+      assert read("(#\\a #\\b)") == [[{:char, ?a}, {:char, ?b}]]
+      assert read("'#\\a") == [[sym("quote"), {:char, ?a}]]
+    end
+
+    test "an unknown name is an error" do
+      assert_raise Reader.Error, ~r/unknown character name #\\nope/, fn -> read("#\\nope") end
+      assert_raise Reader.Error, ~r/unterminated character literal/, fn -> read("#\\") end
+    end
+  end
+
+  describe "comments" do
+    test "a line comment runs to the newline" do
+      assert read("1 ; two\n3") == [1, 3]
+      assert read("; only a comment") == []
+    end
+
+    test "a block comment nests" do
+      assert read("#| a |# 7") == [7]
+      assert read("#| a #| b |# c |# 7") == [7]
+      assert read("#|a|#7") == [7]
+      assert read("(1 #| two |# 3)") == [[1, 3]]
+    end
+
+    test "a block comment counts the lines it covers" do
+      assert_raise Reader.Error, ~r/line 3, column 2: unexpected \)/, fn ->
+        read("#| one\ntwo |#\n )")
+      end
+    end
+
+    test "an unterminated block comment is an error" do
+      assert_raise Reader.Error, ~r/unterminated block comment/, fn -> read("#| a") end
+      assert_raise Reader.Error, ~r/unterminated block comment/, fn -> read("#| a #| b |#") end
+    end
+
+    test "#; drops the next form" do
+      assert read("#;(a b) c") == [sym("c")]
+      assert read("(1 #;2 3)") == [[1, 3]]
+      assert read("(1 #;(2 3) 4)") == [[1, 4]]
+      assert read("#;#;1 2 3") == [3]
+      assert read("(a . #;junk b)") == [[sym("a") | sym("b")]]
+    end
+  end
+
+  describe "quote and friends" do
+    test "the four prefixes" do
+      assert read("'a") == [[sym("quote"), sym("a")]]
+      assert read("`a") == [[sym("quasiquote"), sym("a")]]
+      assert read(",a") == [[sym("unquote"), sym("a")]]
+      assert read(",@a") == [[sym("unquote-splicing"), sym("a")]]
+    end
+
+    test "prefixes stack and nest" do
+      assert read("''a") == [[sym("quote"), [sym("quote"), sym("a")]]]
+
+      assert read("`(a ,b ,@c)") ==
+               [
+                 [
+                   sym("quasiquote"),
+                   [sym("a"), [sym("unquote"), sym("b")], [sym("unquote-splicing"), sym("c")]]
+                 ]
+               ]
+    end
+
+    # the old reader had no delimiter for , or ` — ",x" came back as one symbol
+    test "a prefix ends the symbol before it" do
+      assert read("(a,b)") == [[sym("a"), [sym("unquote"), sym("b")]]]
+      assert read("(a`b)") == [[sym("a"), [sym("quasiquote"), sym("b")]]]
+    end
+
+    test "a prefix with nothing after it is an error" do
+      assert_raise Reader.Error, ~r/end of input/, fn -> read("'") end
+      assert_raise Reader.Error, ~r/end of input/, fn -> read(",@") end
+    end
+  end
+
+  describe "lists and dotted pairs" do
+    test "nesting" do
+      assert read("(1 (2 (3)) ())") == [[1, [2, [3]], []]]
+    end
+
+    test "a dot makes an improper list" do
+      assert read("(a . b)") == [[sym("a") | sym("b")]]
+      assert read("(a b . c)") == [[sym("a"), sym("b") | sym("c")]]
+    end
+
+    test "a list tail after the dot flattens" do
+      assert read("(a . (b c))") == [[sym("a"), sym("b"), sym("c")]]
+      assert read("(a . ())") == [[sym("a")]]
+    end
+
+    test "a lone dot is only special inside a list" do
+      assert read("(a . b)") == [[sym("a") | sym("b")]]
+      assert_raise Reader.Error, ~r/unexpected \. outside a list/, fn -> read(".") end
+      assert read("(... a)") == [[sym("..."), sym("a")]]
+    end
+
+    test "a malformed dotted pair names its position" do
+      assert_raise Reader.Error,
+                   ~r/line 1, column 2: a dotted pair needs a value before the \./,
+                   fn ->
+                     read("(. b)")
+                   end
+
+      assert_raise Reader.Error,
+                   ~r/line 1, column 8: a dotted pair takes one value after the \./,
+                   fn ->
+                     read("(a . b c)")
+                   end
+    end
+
+    test "unterminated and unopened lists" do
+      assert_raise Reader.Error, ~r/line 1, column 1: unterminated list/, fn -> read("(1 2") end
+      assert_raise Reader.Error, ~r/unexpected \)/, fn -> read(")") end
+      assert_raise Reader.Error, ~r/end of input/, fn -> read("(a .") end
+    end
+  end
+
+  describe "positions" do
+    test "the error names the line and the column of the offending token" do
+      e = assert_raise Reader.Error, fn -> read("(a)\n(b)\n  )") end
+      assert e.line == 3
+      assert e.column == 3
+      assert e.message =~ "line 3, column 3"
+    end
+
+    test "an unterminated list points at the open paren" do
+      e = assert_raise Reader.Error, fn -> read("(a\n b\n c") end
+      assert {e.line, e.column} == {1, 1}
+    end
+
+    test "a column counts characters, not bytes" do
+      e = assert_raise Reader.Error, fn -> read("(λλλ #foo)") end
+      assert e.column == 6
+    end
+
+    test "a comment does not lose the line count" do
+      e = assert_raise Reader.Error, fn -> read("; one\n; two\n)") end
+      assert e.line == 3
+    end
+  end
+
+  describe "read_one" do
+    test "returns the form and the unread text" do
+      assert {:ok, form, rest} = Reader.read_one("(a b) (c) ")
+      assert form == [sym("a"), sym("b")]
+      assert String.trim(rest) == "(c)"
+      assert Reader.read_all(rest) == [[sym("c")]]
+    end
+
+    test "reads through a leading comment" do
+      assert {:ok, 1, rest} = Reader.read_one("; hi\n1 2")
+      assert String.trim(rest) == "2"
+    end
+
+    test "text that stops mid-form asks for more" do
+      assert {:incomplete, _} = Reader.read_one("(a b")
+      assert {:incomplete, _} = Reader.read_one(~S{"abc})
+      assert {:incomplete, _} = Reader.read_one("'")
+      assert {:incomplete, _} = Reader.read_one("")
+      assert {:incomplete, _} = Reader.read_one("   \n ")
+    end
+
+    test "the error carries the incomplete flag" do
+      for src <- ["(a b", ~S{"abc}, "|abc", "#| a", "#\\"] do
+        e = assert_raise Reader.Error, fn -> Reader.read_all(src) end
+        assert e.incomplete, "expected #{inspect(src)} to read as incomplete"
+      end
+
+      for src <- [")", "#foo", "(. b)", "#\\nope"] do
+        e = assert_raise Reader.Error, fn -> Reader.read_all(src) end
+        refute e.incomplete, "expected #{inspect(src)} to be a hard error"
+      end
+    end
+
+    test "a real syntax error reports now" do
+      assert {:error, %Reader.Error{line: 1, column: 1}} = Reader.read_one(")")
+      assert {:error, %Reader.Error{}} = Reader.read_one("#foo")
+    end
+  end
+
+  describe "printing" do
+    test "improper lists print with a dot" do
+      assert show("'(1 . 2)") == "(1 . 2)"
+      assert show("'(1 2 . 3)") == "(1 2 . 3)"
+      assert show("(cons 1 2)") == "(1 . 2)"
+      assert show("(cons 1 '(2))") == "(1 2)"
+    end
+
+    test "characters print by name" do
+      assert show("'#\\a") == "#\\a"
+      assert show("'#\\space") == "#\\space"
+      assert show("'#\\newline") == "#\\newline"
+      assert show("(integer->char 955)") == "#\\λ"
+    end
+
+    test "display shows the bare character" do
+      assert Printer.display({:char, ?a}) == "a"
+      assert Printer.display([{:char, ?a} | {:char, ?b}]) == "(a . b)"
+    end
+
+    test "read then print round-trips" do
+      for src <- ["(1 2 3)", "(1 . 2)", "(1 2 . 3)", "(a (b . c) d)", "#\\space", "#\\a", "()"] do
+        assert show("'" <> src) == src
+      end
+    end
+  end
+
+  describe "pairs at the value level" do
+    test "car and cdr reach into a dotted pair" do
+      assert run("(car '(1 . 2))") == 1
+      assert run("(cdr '(1 . 2))") == 2
+      assert run("(cdr '(1 2 . 3))") == [2 | 3]
+    end
+
+    test "list? tells a proper list from a pair" do
+      assert run("(list? '(1 2))") == true
+      assert run("(list? '())") == true
+      assert run("(list? (cons 1 2))") == false
+      assert run("(list? 5)") == false
+    end
+
+    test "pair? and null? still hold" do
+      assert run("(pair? (cons 1 2))") == true
+      assert run("(null? '())") == true
+    end
+
+    test "a dotted pair is data, not a call" do
+      assert err("(+ . 1)") =~ "cannot call a dotted pair"
+    end
+  end
+
+  describe "characters at the value level" do
+    test "the character predicates and conversions" do
+      assert run("(char? #\\a)") == true
+      assert run("(char? \"a\")") == false
+      assert run("(char->integer #\\A)") == 65
+      assert run("(integer->char 65)") == {:char, ?A}
+      assert run("(char->string #\\λ)") == "λ"
+      assert run("(string->char \"abc\")") == {:char, ?a}
+    end
+
+    test "a character evaluates to itself and compares by value" do
+      assert run("#\\a") == {:char, ?a}
+      assert run("(equal? #\\a #\\a)") == true
+      assert run("(equal? #\\a #\\b)") == false
+    end
+  end
+
+  describe "quasiquote" do
+    test "with no unquote it is quote" do
+      assert run("`(1 2 3)") == [1, 2, 3]
+      assert run("`a") == sym("a")
+    end
+
+    test "unquote evaluates one hole" do
+      assert run("(define x 5) `(a ,x b)") == [sym("a"), 5, sym("b")]
+      assert run("`,(+ 1 2)") == 3
+    end
+
+    test "unquote-splicing opens a list into the template" do
+      assert run("`(1 ,@(list 2 3) 4)") == [1, 2, 3, 4]
+      assert run("`(,@(list 1 2))") == [1, 2]
+      assert run("`(1 ,@'())") == [1]
+    end
+
+    test "splicing a non-list is an error" do
+      assert err("`(1 ,@2)") =~ "unquote-splicing needs a list"
+    end
+
+    test "it reaches into nested lists" do
+      assert run("(define x 9) `(a (b ,x) c)") == [sym("a"), [sym("b"), 9], sym("c")]
+    end
+
+    test "an unquote in the tail is the dotted tail" do
+      assert run("`(1 . ,(+ 1 1))") == [1 | 2]
+      assert run("`(1 2 . ,(list 9))") == [1, 2, 9]
+      assert run("`(a . b)") == [sym("a") | sym("b")]
+    end
+
+    test "a nested quasiquote keeps its own template" do
+      assert show("`(a `(b ,(c)))") == "(a (quasiquote (b (unquote (c)))))"
+      assert show("``(a ,,(+ 1 2))") == "(quasiquote (a (unquote 3)))"
+    end
+
+    test "vectors of values survive" do
+      assert run("(define f (lambda (n) (* n 2))) `(x ,(f 4))") == [sym("x"), 8]
+    end
+  end
+
+  describe "the reader still reads what it always read" do
+    test "the shipped Scheme library parses" do
+      for f <- Path.wildcard(Path.join(__DIR__, "../../../aimax_core/priv/*.scm")) do
+        forms = f |> File.read!() |> Reader.read_all()
+        assert is_list(forms) and forms != [], "#{Path.basename(f)} read as nothing"
+      end
+    end
+
+    test "every form in the library is a list or an atom, never a stray dot" do
+      for f <- Path.wildcard(Path.join(__DIR__, "../../../aimax_core/priv/*.scm")),
+          form <- f |> File.read!() |> Reader.read_all() do
+        assert is_list(form),
+               "#{Path.basename(f)}: top-level form is not a list: #{inspect(form)}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
The reader now reads the rest of the Scheme surface syntax, and every error names a line and a column.

## New syntax

| Syntax | Reads as |
|---|---|
| `(a . b)`, `(a b . c)` | improper list `[a \| b]`; `(a . (b c))` flattens |
| `` `x ,x ,@x `` | `quasiquote` / `unquote` / `unquote-splicing` |
| `#\a #\space #\x41 #\λ` | `{:char, codepoint}` |
| `#true #false` | the long boolean names |
| `#x1f #o17 #b1010 #d-9` | integers |
| `\|a symbol\|` | a symbol with any characters in the name |
| `#\| nested \|#`, `#;datum` | block comment, which nests; datum comment |
| `"a\x41;b"` | hex codepoint in a string |

A backslash before a newline folds the line break away.

Errors read `line 3, column 12: unexpected )`. The exception carries `line`, `column`, and an `incomplete` flag.

## Behaviour that had to stay

An unknown string escape keeps its backslash. The library holds regexes like `"^\*+ "` in plain strings, and the old reader passed those through. A test locks it down.

## What the reader forces

- **printer** — improper lists print as `(1 2 . 3)`; characters print by name.
- **eval** — a quasiquote engine that counts nesting depth, splices lists, and handles a dotted tail (`` `(1 . ,(+ 1 1)) `` is `(1 . 2)`). Characters evaluate to themselves. `(f . x)` raises "cannot call a dotted pair" in place of a raw `FunctionClauseError`.
- **builtins** — `cons` takes any tail, `list?` tells a proper list from a pair, and the character conversions arrive: `char?`, `char->integer`, `integer->char`, `char->string`, `string->char`.

## New API

`read_one/1` returns `{:ok, form, rest}`, `{:incomplete, reason}`, or `{:error, exception}`. A REPL asks for the next line instead of reporting a false error.

## Tests

66 new tests in `apps/aimax_scheme/test/aimax/scheme_reader_test.exs`. `mix test` in `aimax_scheme` is 141 passed.

I also read all of `apps/aimax_core/priv/*.scm` with the old reader and the new one and compared the terms. They are identical, file for file.

## What stays out

Vectors `#(...)` and rationals `1/2`. Both need a new value type across the interpreter, which is a larger change than the reader. `#(` is now a clear error, not a silent symbol.
